### PR TITLE
fix(links): render the page the design describes when the channel has no videos yet

### DIFF
--- a/app/css/components.css
+++ b/app/css/components.css
@@ -681,6 +681,14 @@
     );
   }
 
+  .links-thumb-placeholder {
+    background-image: repeating-linear-gradient(
+      135deg,
+      var(--color-primary-quiet) 0 5px,
+      transparent 5px 10px
+    );
+  }
+
   .links-channel-card {
     background-image: linear-gradient(180deg, var(--color-primary-faint), var(--color-glow-03));
   }
@@ -716,6 +724,7 @@
     .links-main-grid {
       display: grid;
       grid-template-columns: 1.3fr 1fr;
+      grid-auto-flow: row dense;
       column-gap: 26px;
     }
 
@@ -727,7 +736,6 @@
 
     .links-identity {
       grid-column: 1 / -1;
-      grid-row: 1;
       padding: 14px 26px 0;
     }
 
@@ -753,31 +761,26 @@
 
     .links-col[data-col="channel"] {
       grid-column: 1;
-      grid-row: 2;
       padding-inline-start: 26px;
     }
 
     .links-col[data-col="history"] {
       grid-column: 2;
-      grid-row: 2;
       padding-inline-end: 26px;
     }
 
     .links-col[data-col="playlists"] {
       grid-column: 2;
-      grid-row: 3;
       padding-inline-end: 26px;
     }
 
     .links-col[data-col="qr"] {
       grid-column: 1;
-      grid-row: 3;
       padding-inline-start: 26px;
     }
 
     .links-footer {
       grid-column: 1 / -1;
-      grid-row: 4;
       margin: 30px 26px 26px;
     }
   }

--- a/components/links/ChannelCard.test.tsx
+++ b/components/links/ChannelCard.test.tsx
@@ -5,6 +5,7 @@ import type { ChannelFeed } from '@/lib/links/feed';
 import { ChannelCard } from './ChannelCard';
 
 vi.mock('next/image', () => ({
+  // biome-ignore lint/performance/noImgElement: this IS the jsdom stand-in for next/image, so there is no image pipeline to prefer and no LCP to guard.
   default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
 }));
 

--- a/components/links/ChannelCard.test.tsx
+++ b/components/links/ChannelCard.test.tsx
@@ -1,0 +1,73 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { LINKS_LOCALE } from '@/content/links.constants';
+import type { ChannelFeed } from '@/lib/links/feed';
+import { ChannelCard } from './ChannelCard';
+
+vi.mock('next/image', () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
+}));
+
+const CHANNEL_URL = 'https://www.youtube.com/@eriknagringa';
+
+const emptyFeed: ChannelFeed = {
+  latest: null,
+  history: [],
+  stats: {},
+  channelUrl: CHANNEL_URL,
+};
+
+const populatedFeed: ChannelFeed = {
+  latest: {
+    id: 'abc',
+    title: 'Montei um time de 12 agentes',
+    url: 'https://www.youtube.com/watch?v=abc',
+    thumbnailUrl: 'https://i.ytimg.com/vi/abc/hqdefault.jpg',
+    publishedAt: '2026-08-28T19:00:00+00:00',
+    description: 'O setup completo.',
+    duration: '14:32',
+  },
+  history: [],
+  stats: { subscriberCount: 12400, videoCount: 48 },
+  channelUrl: CHANNEL_URL,
+};
+
+describe('ChannelCard', () => {
+  it('keeps the 16:9 block before the first video exists, so the card holds its shape', () => {
+    const { container } = render(<ChannelCard locale={LINKS_LOCALE.pt} feed={emptyFeed} />);
+    expect(container.querySelector('.links-thumb-placeholder')).not.toBeNull();
+    expect(container.textContent).toContain('Sem vídeos por aqui ainda');
+  });
+
+  it('offers subscribing even with nothing to watch yet, and does not offer watching', () => {
+    const { container } = render(<ChannelCard locale={LINKS_LOCALE.pt} feed={emptyFeed} />);
+    expect(container.querySelector('[data-outbound="inscrever"]')).not.toBeNull();
+    expect(container.querySelector('[data-outbound="assistir"]')).toBeNull();
+    expect(container.querySelector('[data-outbound="ultimo-video"]')).toBeNull();
+  });
+
+  it('omits counts entirely when the Data API key is absent rather than showing zero', () => {
+    const { container } = render(<ChannelCard locale={LINKS_LOCALE.pt} feed={emptyFeed} />);
+    expect(container.textContent).not.toMatch(/\d+\s*(vídeos|mil|K)/);
+  });
+
+  it('swaps the placeholder for the real video once the feed returns one', () => {
+    const { container } = render(<ChannelCard locale={LINKS_LOCALE.pt} feed={populatedFeed} />);
+    expect(container.querySelector('.links-thumb-placeholder')).toBeNull();
+    expect(container.textContent).toContain('Montei um time de 12 agentes');
+    expect(container.querySelector('[data-outbound="ultimo-video"]')).not.toBeNull();
+    expect(container.querySelector('[data-outbound="assistir"]')).not.toBeNull();
+  });
+
+  it('renders the counts the Data API supplied', () => {
+    const { container } = render(<ChannelCard locale={LINKS_LOCALE.pt} feed={populatedFeed} />);
+    expect(container.textContent?.replace(/\s+/g, ' ')).toMatch(/12,4 mil . 48 vídeos/);
+  });
+
+  it('tags the subscribe link with sub_confirmation and the bio campaign', () => {
+    const { container } = render(<ChannelCard locale={LINKS_LOCALE.pt} feed={emptyFeed} />);
+    const href = container.querySelector('[data-outbound="inscrever"]')?.getAttribute('href') ?? '';
+    expect(href).toContain('sub_confirmation=1');
+    expect(new URL(href).searchParams.get('utm_source')).toBe('bio');
+  });
+});

--- a/components/links/ChannelCard.tsx
+++ b/components/links/ChannelCard.tsx
@@ -56,9 +56,17 @@ export function ChannelCard({ locale, feed }: { locale: LinksLocale; feed: Chann
         </div>
 
         {latest === null ? (
-          <p className="mt-3 mb-0 text-tertiary-400 text-[11.5px] leading-[1.6]">
-            {copy.feedUnavailable[locale]}
-          </p>
+          <div className="mt-3">
+            <div
+              aria-hidden="true"
+              className="links-thumb-placeholder h-[104px] lg:h-[280px] border border-primary-border grid place-items-center text-primary-400 text-[10px] tracking-[0.08em] uppercase"
+            >
+              {copy.thumbPlaceholder[locale]}
+            </div>
+            <p className="mt-[10px] mb-0 text-tertiary-400 text-[11.5px] leading-[1.6] text-pretty">
+              {copy.feedUnavailable[locale]}
+            </p>
+          </div>
         ) : (
           <a
             href={withUtm(latest.url, 'ultimo-video')}

--- a/components/links/IdentityCard.tsx
+++ b/components/links/IdentityCard.tsx
@@ -1,6 +1,5 @@
 import { linksContent } from '@/content/links';
 import type { LinksLocale } from '@/content/links.constants';
-import { Badge } from '@/design-system';
 import { TaglineTyper } from './client/TaglineTyper.client';
 
 export function IdentityCard({ locale }: { locale: LinksLocale }) {
@@ -12,9 +11,10 @@ export function IdentityCard({ locale }: { locale: LinksLocale }) {
     {
       label: copy.statusLabel[locale],
       value: (
-        <Badge variant="dot" size="sm">
+        <span className="inline-flex items-center gap-[6px]">
+          <span className="badge-dot" aria-hidden="true" />
           {profile.status[locale]}
-        </Badge>
+        </span>
       ),
     },
   ];

--- a/components/links/VideoHistory.test.tsx
+++ b/components/links/VideoHistory.test.tsx
@@ -5,6 +5,7 @@ import type { ChannelFeed } from '@/lib/links/feed';
 import { VideoHistory } from './VideoHistory';
 
 vi.mock('next/image', () => ({
+  // biome-ignore lint/performance/noImgElement: this IS the jsdom stand-in for next/image, so there is no image pipeline to prefer and no LCP to guard.
   default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
 }));
 

--- a/components/links/VideoHistory.test.tsx
+++ b/components/links/VideoHistory.test.tsx
@@ -1,0 +1,89 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { LINKS_LOCALE } from '@/content/links.constants';
+import type { ChannelFeed } from '@/lib/links/feed';
+import { VideoHistory } from './VideoHistory';
+
+vi.mock('next/image', () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
+}));
+
+const CHANNEL_URL = 'https://www.youtube.com/@eriknagringa';
+
+function feedWith(count: number): ChannelFeed {
+  return {
+    latest: null,
+    history: Array.from({ length: count }, (_, i) => ({
+      id: `id-${i}`,
+      title: `Vídeo ${i + 1}`,
+      url: `https://www.youtube.com/watch?v=id-${i}`,
+      thumbnailUrl: `https://i.ytimg.com/vi/id-${i}/hqdefault.jpg`,
+      publishedAt: '2026-08-28T19:00:00+00:00',
+      ...(i === 0 ? { duration: '14:32', viewCount: 9100 } : {}),
+    })),
+    stats: {},
+    channelUrl: CHANNEL_URL,
+  };
+}
+
+const empty = feedWith(0);
+
+describe('VideoHistory', () => {
+  it('keeps its section and heading when the channel has no videos yet', () => {
+    const { container } = render(<VideoHistory locale={LINKS_LOCALE.pt} feed={empty} />);
+    expect(container.querySelector('[data-col="history"]')).not.toBeNull();
+    expect(container.querySelector('h2')?.textContent).toContain('últimos vídeos');
+  });
+
+  it('states there are no entries rather than showing placeholder rows', () => {
+    const { container } = render(<VideoHistory locale={LINKS_LOCALE.pt} feed={empty} />);
+    expect(container.querySelectorAll('li')).toHaveLength(0);
+    expect(container.textContent).toContain('nenhuma entrada ainda');
+  });
+
+  it('hides the see-all link while there is nothing to see all of', () => {
+    const { container } = render(<VideoHistory locale={LINKS_LOCALE.pt} feed={empty} />);
+    expect(container.querySelector('a[data-outbound="todos-videos"]')).toBeNull();
+  });
+
+  it('renders one row per video once the feed returns some', () => {
+    const { container } = render(<VideoHistory locale={LINKS_LOCALE.pt} feed={feedWith(5)} />);
+    expect(container.querySelectorAll('li')).toHaveLength(5);
+    expect(container.textContent).not.toContain('nenhuma entrada ainda');
+  });
+
+  it('numbers the rows and tags each link for attribution', () => {
+    const { container } = render(<VideoHistory locale={LINKS_LOCALE.pt} feed={feedWith(3)} />);
+    const links = [...container.querySelectorAll('li a')];
+    expect(links.map((a) => a.getAttribute('data-outbound'))).toEqual([
+      'video-1',
+      'video-2',
+      'video-3',
+    ]);
+    expect(container.textContent).toContain('01');
+    expect(container.textContent).toContain('03');
+  });
+
+  it('shows duration and views only for the entries that carry them', () => {
+    const { container } = render(<VideoHistory locale={LINKS_LOCALE.pt} feed={feedWith(2)} />);
+    const rows = [...container.querySelectorAll('li')];
+    // Intl compact notation separates "9,1" and "mil" with a non-breaking space, so the
+    // whitespace here is matched loosely rather than typed literally.
+    expect(rows[0]?.textContent?.replace(/\s+/g, ' ')).toMatch(/14:32 . 9,1 mil visualizações/);
+    expect(
+      rows[1]?.textContent,
+      'the second entry carries neither duration nor viewCount, so its meta line must not invent them',
+    ).not.toMatch(/14:32|visualizações/);
+  });
+
+  it('restores the see-all link once videos exist', () => {
+    const { container } = render(<VideoHistory locale={LINKS_LOCALE.pt} feed={feedWith(5)} />);
+    const seeAll = container.querySelector('a[data-outbound="todos-videos"]');
+    expect(seeAll?.getAttribute('href')).toContain(`${CHANNEL_URL}/videos`);
+  });
+
+  it('localises the view count word on the English route', () => {
+    const { container } = render(<VideoHistory locale={LINKS_LOCALE.en} feed={feedWith(1)} />);
+    expect(container.textContent).toContain('9.1K views');
+  });
+});

--- a/components/links/VideoHistory.tsx
+++ b/components/links/VideoHistory.tsx
@@ -29,7 +29,7 @@ function meta(
 
 export function VideoHistory({ locale, feed }: { locale: LinksLocale; feed: ChannelFeed }) {
   const { copy } = linksContent;
-  if (feed.history.length === 0) return null;
+  const isEmpty = feed.history.length === 0;
 
   return (
     <section
@@ -41,44 +41,55 @@ export function VideoHistory({ locale, feed }: { locale: LinksLocale; feed: Chan
         {copy.latestHeading[locale]}
       </SectionHeading>
 
-      <ol className="list-none m-0 p-0 border border-primary-border bg-[var(--color-glow-03)]">
-        {feed.history.map((video, index) => (
-          <li key={video.id} className="border-b border-primary-quiet last:border-b-0">
-            <a
-              href={withUtm(video.url, `video-${index + 1}`)}
-              target="_blank"
-              rel="noopener noreferrer"
-              data-outbound={`video-${index + 1}`}
-              className="grid grid-cols-[20px_64px_1fr_auto] gap-[11px] items-center py-[11px] px-[13px] no-underline transition-colors duration-150 hover:bg-[var(--color-glow-06)] focus-visible:outline-2 focus-visible:outline-primary-500 focus-visible:-outline-offset-2"
-            >
-              <span className="text-primary-400 text-[11px]">
-                {String(index + 1).padStart(INDEX_PAD, '0')}
-              </span>
-              <Image
-                src={video.thumbnailUrl}
-                alt=""
-                width={THUMB_WIDTH}
-                height={THUMB_HEIGHT}
-                sizes="64px"
-                className="border border-primary-border object-cover h-9 w-16"
-              />
-              <span>
-                <span className="block text-tertiary-50 text-[12.5px] leading-[1.45] text-pretty">
-                  {video.title}
-                </span>
-                <span className="block text-tertiary-400 text-[10px] mt-0.5">
-                  {meta(video, locale, copy.viewsWord[locale])}
-                </span>
-              </span>
-              <span aria-hidden="true" className="text-primary-subtle text-xs">
-                →
-              </span>
-            </a>
-          </li>
-        ))}
-      </ol>
+      {isEmpty && (
+        <p className="m-0 border border-primary-border bg-[var(--color-glow-03)] py-[14px] px-[13px] text-tertiary-400 text-[11.5px] leading-[1.6]">
+          <span aria-hidden="true" className="text-primary-400">
+            ${' '}
+          </span>
+          {copy.historyEmpty[locale]}
+        </p>
+      )}
 
-      {feed.channelUrl !== null && (
+      {!isEmpty && (
+        <ol className="list-none m-0 p-0 border border-primary-border bg-[var(--color-glow-03)]">
+          {feed.history.map((video, index) => (
+            <li key={video.id} className="border-b border-primary-quiet last:border-b-0">
+              <a
+                href={withUtm(video.url, `video-${index + 1}`)}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-outbound={`video-${index + 1}`}
+                className="grid grid-cols-[20px_64px_1fr_auto] gap-[11px] items-center py-[11px] px-[13px] no-underline transition-colors duration-150 hover:bg-[var(--color-glow-06)] focus-visible:outline-2 focus-visible:outline-primary-500 focus-visible:-outline-offset-2"
+              >
+                <span className="text-primary-400 text-[11px]">
+                  {String(index + 1).padStart(INDEX_PAD, '0')}
+                </span>
+                <Image
+                  src={video.thumbnailUrl}
+                  alt=""
+                  width={THUMB_WIDTH}
+                  height={THUMB_HEIGHT}
+                  sizes="64px"
+                  className="border border-primary-border object-cover h-9 w-16"
+                />
+                <span>
+                  <span className="block text-tertiary-50 text-[12.5px] leading-[1.45] text-pretty">
+                    {video.title}
+                  </span>
+                  <span className="block text-tertiary-400 text-[10px] mt-0.5">
+                    {meta(video, locale, copy.viewsWord[locale])}
+                  </span>
+                </span>
+                <span aria-hidden="true" className="text-primary-subtle text-xs">
+                  →
+                </span>
+              </a>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      {!isEmpty && (
         <a
           href={withUtm(`${feed.channelUrl}/videos`, 'todos-videos')}
           target="_blank"

--- a/content/links.ts
+++ b/content/links.ts
@@ -92,6 +92,11 @@ export const linksContent: LinksContent = LinksContentSchema.parse({
     viewsWord: { pt: 'visualizações', en: 'views' },
     latestHeading: { pt: 'últimos vídeos', en: 'latest videos' },
     historyCommand: 'history -5',
+    thumbPlaceholder: { pt: 'primeiro vídeo · 16:9', en: 'first video · 16:9' },
+    historyEmpty: {
+      pt: 'nenhuma entrada ainda · o primeiro vídeo aparece aqui sozinho',
+      en: 'no entries yet · the first video lands here on its own',
+    },
     seeAllVideos: { pt: 'ver todos os vídeos', en: 'see all videos' },
     playlistsHeading: { pt: 'playlists', en: 'playlists' },
     qrHeading: { pt: 'levar a página com você', en: 'take this page with you' },

--- a/content/schemas.ts
+++ b/content/schemas.ts
@@ -307,6 +307,8 @@ export const LinksCopySchema = z.object({
   viewsWord: LocalizedTextSchema,
   latestHeading: LocalizedTextSchema,
   historyCommand: z.string().min(1),
+  historyEmpty: LocalizedTextSchema,
+  thumbPlaceholder: LocalizedTextSchema,
   seeAllVideos: LocalizedTextSchema,
   playlistsHeading: LocalizedTextSchema,
   qrHeading: LocalizedTextSchema,


### PR DESCRIPTION
## Summary

- **The reported "missing on mobile" was missing everywhere.** `VideoHistory` returned `null` on an empty feed, and the channel has no published videos. It looked mobile-specific only because the ≥1100px grid left a visible hole where the section belongs, while mobile stacks.
- **The hole was introduced by my port.** The design places sections positionally (`nth-of-type`), so a removed section never gaps — the rest shift up. I ported that to semantic `data-col` selectors, which reads better but pinned each section to a fixed `grid-row`. Now `grid-auto-flow: row dense` with no explicit rows: gap-free like the reference, and unlike `nth-of-type` it does not break silently when DOM order changes.
- **The page now renders what the design describes, with our data as the truth.** Empty-state for the history section, and the design's own 16:9 hatch placeholder in the channel card.

## Type of change

- [x] `fix` — bug fix
- [ ] `feat` / `refactor` / `perf` / `chore`

## Test plan

- [x] `pnpm ci:local` — 175 files, 1348 tests
- [x] Playwright `links.spec.ts` + `a11y` + `visual` — **60 passed, 1 skipped**, across chromium, chromium-mobile, webkit-desktop, webkit-mobile
- [x] route-js `/links` and `/links/en` — **156.8 KB total, 14.6 KB app-owned** of 32.8, unchanged
- [x] `pnpm bundle-check`

## Visual changes

- [x] Desktop (1440) + mobile (375) verified against the design reference
- [x] **Visual-regression baselines: NOT required.** `visual.spec.ts` captures sections of `/` only; every change here is inside `/links`, its content module and its own `.links-*` CSS. The full visual suite passes unchanged, which is the evidence rather than the claim.

Before → after, wide: the right column went from an empty cell to the `ÚLTIMOS VÍDEOS` panel; the channel card went from a bare line to the 16:9 block plus subscribe CTA.

## What the comparison caught beyond the report

The status row used the design-system `Badge` — bordered, uppercase, padded — where the reference uses a bare pulsing dot with sentence case. In the narrow meta column that `Badge` wrapped and stranded its dot on its own line. It is an inline dot now: matches the reference, fixes the wrap, and removes a component level.

## Deliberately still absent

The reference shows `12.4k · 48 vídeos` and an Instagram pill. Both are mockup placeholders:

- Counts come from the YouTube Data API and render only when `YOUTUBE_API_KEY` is set. Without it they are omitted rather than invented.
- No Instagram handle has been confirmed, so that pill stays filtered out by the same rule that keeps a guessed destination off a public page.

No ghost/skeleton rows in the empty history panel either — a skeleton implies content that is loading, not content that does not exist yet.

## Checklist

- [x] No hardcoded hex / magic numbers — reuses `--color-glow-03`, `--color-primary-border/quiet/400`, and the existing `.badge-dot`
- [x] No `use client` added
- [x] Bundle size assessed — unchanged
- [x] A11y considered — dot is `aria-hidden`, section keeps its `aria-labelledby`; axe green on both routes
- [x] Reversible — `git revert`
- [ ] ADR — not needed; no architectural decision, this restores the documented design
